### PR TITLE
[Change] User has more than one role

### DIFF
--- a/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/authentication/service/AuthenticationUserDetailService.kt
+++ b/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/authentication/service/AuthenticationUserDetailService.kt
@@ -17,7 +17,7 @@ class AuthenticationUserDetailService(
         User(
             it.username,
             it.password,
-            getAuthorities(it.role)
+            getAuthorities(it.roles.toString())
         )
     } ?: throw UserUnregisteredException(username)
 

--- a/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/model/Role.kt
+++ b/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/model/Role.kt
@@ -1,0 +1,14 @@
+package com.eureka.authenticationservice.api.user.model
+enum class Role{ 
+    ADMIN, USER;
+
+    companion object {
+        fun transform(rolesString: String): ArrayList<Role> {
+            val roles = arrayListOf<Role>()
+            for (role in rolesString.split(",")) {
+                roles.add(valueOf(role.uppercase().trim()))
+            }
+            return roles
+        }
+    }
+}

--- a/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/model/User.kt
+++ b/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/model/User.kt
@@ -7,8 +7,8 @@ data class User(
     val id: Long?,
     val username: String,
     val password: String,
-    val role: String
+    val roles: List<Role>
 ) {
-    fun toUserDto() = UserDto(id, username, password, role)
+    fun toUserDto() = UserDto(id, username, password, ArrayList(roles))
     fun toUserCreateResponse() = UserCreateResponse(id!!, username)
 }

--- a/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/model/request/UserCreateRequest.kt
+++ b/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/model/request/UserCreateRequest.kt
@@ -1,11 +1,12 @@
 package com.eureka.authenticationservice.api.user.model.request
 
+import com.eureka.authenticationservice.api.user.model.Role
 import com.eureka.authenticationservice.api.user.model.User
 
 data class UserCreateRequest(
     val username: String,
     val password: String,
-    val role: String
+    val roles: List<Role>
 ) {
-    fun toUser(): User = User(null, username, password, role)
+    fun toUser(): User = User(null, username, password, roles)
 }

--- a/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/repository/UserDto.kt
+++ b/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/repository/UserDto.kt
@@ -1,5 +1,6 @@
 package com.eureka.authenticationservice.api.user.repository
 
+import com.eureka.authenticationservice.api.user.model.Role
 import com.eureka.authenticationservice.api.user.model.User
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -15,7 +16,7 @@ class UserDto(
     val id: Long?,
     val username: String,
     val password: String,
-    val role: String
+    val roles: ArrayList<Role>
 ) {
-    fun toUser() = User(id, username, password, role)
+    fun toUser() = User(id, username, password, roles)
 }

--- a/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/service/UserService.kt
+++ b/authentication-service/src/main/kotlin/com/eureka/authenticationservice/api/user/service/UserService.kt
@@ -26,7 +26,7 @@ class UserService(
             null,
             user.username,
             passwordEncoder.encode(user.password),
-            user.role
+            ArrayList(user.roles)
         )
         return userRepository.save(encoderUser).toUser()
     }

--- a/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/authentication/filter/JWTAuthenticationFilterTest.kt
+++ b/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/authentication/filter/JWTAuthenticationFilterTest.kt
@@ -1,5 +1,6 @@
 package com.eureka.authenticationservice.api.authentication.filter
 
+import com.eureka.authenticationservice.api.user.model.Role
 import com.eureka.authenticationservice.api.user.model.request.UserCreateRequest
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
@@ -20,11 +21,11 @@ internal class JWTAuthenticationFilterTest {
     private val jWTAuthenticationFilter = JWTAuthenticationFilter(authenticationManager)
     private val request = MockHttpServletRequest()
     private val response = MockHttpServletResponse()
-    private val user = UserCreateRequest("User1", "pass", "ADMIN")
+    private val user = UserCreateRequest("User1", "pass", listOf(Role.ADMIN))
     private val fakeUsernamePasswordAuthenticationToken = UsernamePasswordAuthenticationToken(
         "principal",
         "credentials",
-        listOf(SimpleGrantedAuthority("user"))
+        listOf(SimpleGrantedAuthority("ADMIN"))
     )
 
     @Test

--- a/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/authentication/service/AuthenticationUserDetailServiceTest.kt
+++ b/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/authentication/service/AuthenticationUserDetailServiceTest.kt
@@ -1,5 +1,6 @@
 package com.eureka.authenticationservice.api.authentication.service
 
+import com.eureka.authenticationservice.api.user.model.Role
 import com.eureka.authenticationservice.api.user.model.User
 import com.eureka.authenticationservice.api.user.service.UserService
 import com.eureka.authenticationservice.utilities.UserUnregisteredException
@@ -20,7 +21,7 @@ internal class AuthenticationUserDetailServiceTest{
     @Test
     fun  `Given user registered when loadUserByUsername`(){
         val username = "User1"
-        val user = User(id = Long.MAX_VALUE, username = username, password = "pass", role = "ADMIN")
+        val user = User(id = Long.MAX_VALUE, username = username, password = "pass", roles = arrayListOf(Role.ADMIN))
         every { userService.readUserByUsername(username) } returns user
 
         assertEquals(user.username, authenticationService.loadUserByUsername(username).username)

--- a/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/controller/UserControllerTest.kt
+++ b/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/controller/UserControllerTest.kt
@@ -1,6 +1,8 @@
 package com.eureka.authenticationservice.api.user.controller
 
+import com.eureka.authenticationservice.api.user.model.Role
 import com.eureka.authenticationservice.api.user.model.User
+import com.eureka.authenticationservice.api.user.model.request.UserCreateRequest
 import com.eureka.authenticationservice.api.user.model.response.UserCreateResponse
 import com.eureka.authenticationservice.api.user.service.UserService
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -39,22 +41,32 @@ internal class UserControllerTest {
     @Test
     fun canRetrieveByNameWhenExists() {
         val user = User(
-            id = null,
+            id = 1,
             username = "User1",
             password = "000",
-            role = "ADMIN"
+            roles = arrayListOf(Role.ADMIN)
         )
+
+        val userRequest = UserCreateRequest(
+            username = user.username,
+            password = user.password,
+            roles = user.roles
+        )
+
         every { userService.createUser(any()) } returns user
 
         val response: MockHttpServletResponse = mvc.perform(
             post("/api/user")
-                .content(jacksonObjectMapper().writeValueAsString(user))
+                .content(jacksonObjectMapper().writeValueAsString(userRequest))
                 .contentType(MediaType.APPLICATION_JSON)
         )
             .andReturn().response
-        
-        assertEquals(response.status, HttpStatus.CREATED.value())
-        assertEquals(user.toUserCreateResponse(), jacksonObjectMapper().readValue(response.contentAsString, UserCreateResponse::class.java))
+
+        assertEquals(HttpStatus.CREATED.value(), response.status)
+        assertEquals(
+            jacksonObjectMapper().readValue(response.contentAsString, UserCreateResponse::class.java),
+            user.toUserCreateResponse()
+        )
     }
 
     //TODO when user is registered 409 conflict

--- a/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/model/RoleTest.kt
+++ b/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/model/RoleTest.kt
@@ -1,0 +1,11 @@
+package com.eureka.authenticationservice.api.user.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class RoleTest{
+    @Test
+    fun `Transform string to role`(){
+        assertEquals(arrayListOf(Role.ADMIN,Role.USER), Role.transform("ADMIN, USER"))
+    }
+}

--- a/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/model/request/UserCreateRequestTest.kt
+++ b/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/model/request/UserCreateRequestTest.kt
@@ -1,0 +1,21 @@
+package com.eureka.authenticationservice.api.user.model.request
+
+import com.eureka.authenticationservice.api.user.model.Role
+import com.eureka.authenticationservice.api.user.model.User
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class UserCreateRequestTest{
+    @Test
+    fun `Transform to user`(){
+        val userCreate = UserCreateRequest(
+            "User",
+            "11",
+            listOf(Role.ADMIN,Role.USER)
+        )
+        val user = userCreate.toUser()
+
+        assertEquals(User(null,"User","11", arrayListOf(Role.ADMIN,Role.USER)), user)
+    }
+
+}

--- a/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/service/UserServiceTest.kt
+++ b/authentication-service/src/test/kotlin/com/eureka/authenticationservice/api/user/service/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.eureka.authenticationservice.api.user.service
 
+import com.eureka.authenticationservice.api.user.model.Role
 import com.eureka.authenticationservice.api.user.model.User
 import com.eureka.authenticationservice.api.user.repository.UserRepository
 import com.eureka.authenticationservice.utilities.UserAlreadyRegistered
@@ -21,7 +22,7 @@ internal class UserServiceTest {
     @Test
     fun `Given user registered When readUserByUsername Then retrieve user`() {
         val username = "User1"
-        val user = User(id = Long.MAX_VALUE, username = username, password = "pass", role = "ADMIN")
+        val user = User(id = Long.MAX_VALUE, username = username, password = "pass", roles = arrayListOf(Role.USER, Role.ADMIN))
         every { userRepository.findByUsername(username) } returns user
 
         val userRegistered = userService.readUserByUsername(username)
@@ -42,7 +43,7 @@ internal class UserServiceTest {
     @Test
     fun `Given user registered When createUser Then UserException`() {
         val username = "User1"
-        val user = User(id = Long.MAX_VALUE, username = username, password = "pass", role = "ADMIN")
+        val user = User(id = Long.MAX_VALUE, username = username, password = "pass", roles = arrayListOf(Role.ADMIN))
         every { userRepository.findByUsername(username) } returns user
 
         val exception = assertThrows<UserAlreadyRegistered> { userService.createUser(user) }
@@ -53,7 +54,7 @@ internal class UserServiceTest {
     @Test
     fun `Given user unregistered When createUser Then retrieve it`() {
         val username = "User1"
-        val user = User(id = null, username = username, password = "123456", role = "ADMIN")
+        val user = User(id = null, username = username, password = "123456", roles = arrayListOf(Role.ADMIN))
         every { userRepository.findByUsername(username) } returns null
         every { passwordEncoder.encode(user.password)} returns "123456"
         every { userRepository.save(any())} returns user.toUserDto()

--- a/authentication-service/src/test/postman/CRM.postman_collection.json
+++ b/authentication-service/src/test/postman/CRM.postman_collection.json
@@ -1,0 +1,144 @@
+{
+	"info": {
+		"_postman_id": "19b84a18-0184-4cbe-b852-80f531d5cd08",
+		"name": "CRM",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "294271"
+	},
+	"item": [
+		{
+			"name": "Create User",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 201\", function () {\r",
+							"    pm.response.to.have.status(201);\r",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"username\":\"user1\",\n    \"password\": \"user1\",\n    \"roles\": [\"ADMIN\"]\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/user",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"user"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Create User",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\":\"user6\",\n    \"password\": \"user1\",\n    \"roles\": [\"ADMIN\"]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:8080/api/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"user"
+							]
+						}
+					},
+					"status": "Created",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Vary",
+							"value": "Origin"
+						},
+						{
+							"key": "Vary",
+							"value": "Access-Control-Request-Method"
+						},
+						{
+							"key": "Vary",
+							"value": "Access-Control-Request-Headers"
+						},
+						{
+							"key": "X-Content-Type-Options",
+							"value": "nosniff"
+						},
+						{
+							"key": "X-XSS-Protection",
+							"value": "1; mode=block"
+						},
+						{
+							"key": "Cache-Control",
+							"value": "no-cache, no-store, max-age=0, must-revalidate"
+						},
+						{
+							"key": "Pragma",
+							"value": "no-cache"
+						},
+						{
+							"key": "Expires",
+							"value": "0"
+						},
+						{
+							"key": "X-Frame-Options",
+							"value": "DENY"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						},
+						{
+							"key": "Transfer-Encoding",
+							"value": "chunked"
+						},
+						{
+							"key": "Date",
+							"value": "Thu, 25 Aug 2022 17:14:22 GMT"
+						},
+						{
+							"key": "Keep-Alive",
+							"value": "timeout=60"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\": 1,\n    \"username\": \"user6\"\n}"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
**Overview** 
Currently, it is only allowed to register users with only one role, the objective of this implementation is to enable the registration with more than one.

**Changes:**
- The "_role_" parameter changes to "_roles_" both in the API signature and in the user's save.
- Added postman collection to testing API in `test/postman`

 **New cURL to test**
```
curl --location --request POST 'http://localhost:8080/api/user' \
--header 'Content-Type: application/json' \
--data-raw '{
    "username":"user1",
    "password": "user1",
    "roles": ["ADMIN"]
}'
```

**Comment**
In this implementation it has been assumed that we are not in production and the API is not being used, so the performance has been changed abruptly by replacing the role:String parameter with roles:ArrayList. In a production environment, the consensus would be asked as there are several ways to do this.

